### PR TITLE
Improve Tailwind styling

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders dashboard title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const titles = screen.getAllByText(/dashboard nacional/i);
+  expect(titles.length).toBeGreaterThan(0);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,13 +26,13 @@ const App: React.FC = () => {
   };
 
   return (
-    <div className="flex min-h-screen bg-gray-50">
+    <div className="flex min-h-screen bg-gradient-to-br from-neutral-100 to-neutral-200">
       <Sidebar
         currentPage={currentPage}
         setCurrentPage={(page: Page) => setCurrentPage(page)}
       />
       <div className="flex-1 flex flex-col">
-        <header className="bg-white shadow-sm border-b px-6 py-4">
+        <header className="bg-white/70 backdrop-blur-md shadow-sm border-b px-8 py-4">
           <div className="flex items-center justify-between">
             <h2 className="text-2xl font-bold text-gray-800">
               {currentPage === 'dashboard' && 'Dashboard Nacional'}
@@ -51,7 +51,7 @@ const App: React.FC = () => {
             </div>
           </div>
         </header>
-        <main className="flex-1 overflow-auto">
+        <main className="flex-1 overflow-auto p-6">
           {renderCurrentPage()}
         </main>
       </div>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -17,64 +17,64 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ currentPage, setCurrentPage }) => (
-  <div className="bg-gray-900 text-white w-64 min-h-screen p-4">
+  <div className="bg-gradient-to-b from-slate-800 to-slate-900 text-white w-64 min-h-screen p-6 shadow-lg">
     <div className="flex items-center mb-8">
       <Router className="w-8 h-8 mr-3 text-blue-400" />
       <h1 className="text-xl font-bold">MikroManager</h1>
     </div>
-    <nav className="space-y-2">
+    <nav className="space-y-2 text-sm">
       <button
         onClick={() => setCurrentPage('dashboard')}
-        className={`w-full flex items-center p-3 rounded-lg transition-colors ${
-          currentPage === 'dashboard' ? 'bg-blue-600' : 'hover:bg-gray-800'
+        className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg font-medium transition-colors ${
+          currentPage === 'dashboard' ? 'bg-slate-700' : 'hover:bg-slate-700'
         }`}
       >
-        <Globe className="w-5 h-5 mr-3" />
+        <Globe className="w-5 h-5" />
         Dashboard Nacional
       </button>
       <button
         onClick={() => setCurrentPage('testing')}
-        className={`w-full flex items-center p-3 rounded-lg transition-colors ${
-          currentPage === 'testing' ? 'bg-blue-600' : 'hover:bg-gray-800'
+        className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg font-medium transition-colors ${
+          currentPage === 'testing' ? 'bg-slate-700' : 'hover:bg-slate-700'
         }`}
       >
-        <Zap className="w-5 h-5 mr-3" />
+        <Zap className="w-5 h-5" />
         Teste de Internet
       </button>
       <button
         onClick={() => setCurrentPage('users')}
-        className={`w-full flex items-center p-3 rounded-lg transition-colors ${
-          currentPage === 'users' ? 'bg-blue-600' : 'hover:bg-gray-800'
+        className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg font-medium transition-colors ${
+          currentPage === 'users' ? 'bg-slate-700' : 'hover:bg-slate-700'
         }`}
       >
-        <Users className="w-5 h-5 mr-3" />
+        <Users className="w-5 h-5" />
         Usuários Conectados
       </button>
       <button
         onClick={() => setCurrentPage('monitoring')}
-        className={`w-full flex items-center p-3 rounded-lg transition-colors ${
-          currentPage === 'monitoring' ? 'bg-blue-600' : 'hover:bg-gray-800'
+        className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg font-medium transition-colors ${
+          currentPage === 'monitoring' ? 'bg-slate-700' : 'hover:bg-slate-700'
         }`}
       >
-        <Activity className="w-5 h-5 mr-3" />
+        <Activity className="w-5 h-5" />
         Monitoramento
       </button>
       <button
         onClick={() => setCurrentPage('devices')}
-        className={`w-full flex items-center p-3 rounded-lg transition-colors ${
-          currentPage === 'devices' ? 'bg-blue-600' : 'hover:bg-gray-800'
+        className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg font-medium transition-colors ${
+          currentPage === 'devices' ? 'bg-slate-700' : 'hover:bg-slate-700'
         }`}
       >
-        <Server className="w-5 h-5 mr-3" />
+        <Server className="w-5 h-5" />
         Dispositivos Mikrotik
       </button>
       <button
         onClick={() => setCurrentPage('alerts')}
-        className={`w-full flex items-center p-3 rounded-lg transition-colors ${
-          currentPage === 'alerts' ? 'bg-blue-600' : 'hover:bg-gray-800'
+        className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg font-medium transition-colors ${
+          currentPage === 'alerts' ? 'bg-slate-700' : 'hover:bg-slate-700'
         }`}
       >
-        <Bell className="w-5 h-5 mr-3" />
+        <Bell className="w-5 h-5" />
         Alertas & Notificações
       </button>
     </nav>

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,12 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap");
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  @apply bg-neutral-100 text-neutral-800 font-sans antialiased;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/src/pages/alerts.tsx
+++ b/src/pages/alerts.tsx
@@ -49,14 +49,14 @@ const Alerts: React.FC = () => {
   };
 
   return (
-    <div className="p-6">
+    <div className="max-w-7xl mx-auto p-6 space-y-8">
       <div className="mb-6">
         <h1 className="text-3xl font-bold mb-2">Alertas & Notificações</h1>
         <p className="text-gray-600">Central de notificações e configurações de alertas</p>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Alertas Críticos</h3>
             <XCircle className="w-6 h-6 text-red-500" />
@@ -66,7 +66,7 @@ const Alerts: React.FC = () => {
           </div>
           <p className="text-gray-600">requerem atenção imediata</p>
         </div>
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Avisos</h3>
             <AlertTriangle className="w-6 h-6 text-yellow-500" />
@@ -76,7 +76,7 @@ const Alerts: React.FC = () => {
           </div>
           <p className="text-gray-600">alertas de média prioridade</p>
         </div>
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Informações</h3>
             <CheckCircle className="w-6 h-6 text-blue-500" />
@@ -88,7 +88,7 @@ const Alerts: React.FC = () => {
         </div>
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm border mb-6">
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200 mb-6">
         <div className="p-6 border-b flex items-center justify-between">
           <h2 className="text-xl font-semibold">Notificações Recentes</h2>
           <button className="text-blue-600 hover:text-blue-800 text-sm">Marcar todas como lidas</button>
@@ -111,12 +111,12 @@ const Alerts: React.FC = () => {
         </div>
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm border">
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200">
         <div className="p-6 border-b">
           <h2 className="text-xl font-semibold">Configurações de Notificação</h2>
         </div>
         <div className="p-6 grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="border rounded-lg p-4">
+          <div className="border border-slate-200 rounded-lg p-4">
             <div className="flex items-center mb-4">
               <MessageCircle className="w-6 h-6 text-green-600 mr-3" />
               <h3 className="font-semibold">Telegram</h3>
@@ -137,7 +137,7 @@ const Alerts: React.FC = () => {
               Configurar Bot
             </button>
           </div>
-          <div className="border rounded-lg p-4">
+          <div className="border border-slate-200 rounded-lg p-4">
             <div className="flex items-center mb-4">
               <Mail className="w-6 h-6 text-blue-600 mr-3" />
               <h3 className="font-semibold">Email</h3>
@@ -158,7 +158,7 @@ const Alerts: React.FC = () => {
               Configurar SMTP
             </button>
           </div>
-          <div className="border rounded-lg p-4">
+          <div className="border border-slate-200 rounded-lg p-4">
             <div className="flex items-center mb-4">
               <Phone className="w-6 h-6 text-purple-600 mr-3" />
               <h3 className="font-semibold">WhatsApp</h3>

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -41,14 +41,14 @@ const Dashboard: React.FC = () => {
   const [selectedState, setSelectedState] = useState<string | null>(null);
 
   return (
-    <div className="p-6">
+    <div className="max-w-7xl mx-auto p-6 space-y-8">
       <div className="mb-6">
         <h1 className="text-3xl font-bold mb-2">Status das Operadoras - Brasil</h1>
         <p className="text-gray-600">Monitoramento em tempo real das principais operadoras por estado</p>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Status Geral</h3>
             <CheckCircle className="w-6 h-6 text-green-500" />
@@ -56,7 +56,7 @@ const Dashboard: React.FC = () => {
           <div className="text-3xl font-bold text-green-500 mb-2">92%</div>
           <p className="text-gray-600">das conexões estão estáveis</p>
         </div>
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Latência Média</h3>
             <Activity className="w-6 h-6 text-blue-500" />
@@ -64,7 +64,7 @@ const Dashboard: React.FC = () => {
           <div className="text-3xl font-bold text-blue-500 mb-2">42ms</div>
           <p className="text-gray-600">ping médio nacional</p>
         </div>
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Reclamações</h3>
             <AlertTriangle className="w-6 h-6 text-yellow-500" />
@@ -74,7 +74,7 @@ const Dashboard: React.FC = () => {
         </div>
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm border">
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200">
         <div className="p-6 border-b">
           <h2 className="text-xl font-semibold">Status por Estado</h2>
         </div>
@@ -83,7 +83,7 @@ const Dashboard: React.FC = () => {
             {Object.entries(statesData).map(([uf, data]) => (
               <div
                 key={uf}
-                className="border rounded-lg p-4 hover:shadow-md transition-shadow cursor-pointer"
+                className="border border-slate-200 rounded-lg p-4 hover:shadow-md transition-shadow cursor-pointer"
                 onClick={() => setSelectedState(uf)}
               >
                 <div className="flex items-center justify-between mb-3">

--- a/src/pages/devices.tsx
+++ b/src/pages/devices.tsx
@@ -32,7 +32,7 @@ const Devices: React.FC = () => {
   }, []);
 
   return (
-    <div className="p-6">
+    <div className="max-w-7xl mx-auto p-6 space-y-8">
       <div className="mb-6">
         <h1 className="text-3xl font-bold mb-2">Dispositivos Mikrotik</h1>
         <p className="text-gray-600">Gerencie todos os seus dispositivos Mikrotik em um só lugar</p>
@@ -42,13 +42,13 @@ const Devices: React.FC = () => {
           + Adicionar Dispositivo
         </button>
       </div>
-      <div className="bg-white rounded-xl shadow-sm border">
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200">
         <div className="p-6 border-b">
           <h2 className="text-xl font-semibold">Seus Dispositivos</h2>
         </div>
         <div className="p-6 grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
           {devices.map(d => (
-            <div key={d.id} className="border rounded-xl p-6 hover:shadow-lg transition-shadow">
+            <div key={d.id} className="border border-slate-200 rounded-xl p-6 hover:shadow-lg transition-shadow">
               <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center">
                   <Router className="w-8 h-8 text-blue-600 mr-3" />
@@ -95,26 +95,26 @@ const Devices: React.FC = () => {
           ))}
         </div>
       </div>
-      <div className="mt-6 bg-white rounded-xl shadow-sm border">
+      <div className="mt-6 bg-white rounded-xl shadow-sm border border-slate-200">
         <div className="p-6 border-b">
           <h2 className="text-xl font-semibold">Ações Rápidas</h2>
         </div>
         <div className="p-6 grid grid-cols-1 md:grid-cols-3 gap-4">
-          <button className="flex items-center p-4 border rounded-lg hover:bg-gray-50 transition-colors">
+          <button className="flex items-center p-4 border border-slate-200 rounded-lg hover:bg-gray-50 transition-colors">
             <RefreshCw className="w-6 h-6 text-blue-600 mr-3" />
             <div>
               <div className="font-medium">Reiniciar DHCP</div>
               <div className="text-sm text-gray-600">Renovar leases DHCP</div>
             </div>
           </button>
-          <button className="flex items-center p-4 border rounded-lg hover:bg-gray-50 transition-colors">
+          <button className="flex items-center p-4 border border-slate-200 rounded-lg hover:bg-gray-50 transition-colors">
             <Network className="w-6 h-6 text-green-600 mr-3" />
             <div>
               <div className="font-medium">Resetar Interface</div>
               <div className="text-sm text-gray-600">Reiniciar interface de rede</div>
             </div>
           </button>
-          <button className="flex items-center p-4 border rounded-lg hover:bg-gray-50 transition-colors">
+          <button className="flex items-center p-4 border border-slate-200 rounded-lg hover:bg-gray-50 transition-colors">
             <Shield className="w-6 h-6 text-red-600 mr-3" />
             <div>
               <div className="font-medium">Bloquear Intruso</div>

--- a/src/pages/monitoring.tsx
+++ b/src/pages/monitoring.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import { BarChart3, Activity } from 'lucide-react';
 
 const Monitoring: React.FC = () => (
-  <div className="p-6">
+  <div className="max-w-7xl mx-auto p-6 space-y-8">
     <div className="mb-6">
       <h1 className="text-3xl font-bold mb-2">Monitoramento em Tempo Real</h1>
       <p className="text-gray-600">Acompanhe o desempenho da rede em tempo real</p>
     </div>
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-      <div className="bg-white rounded-xl shadow-sm border p-6">
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
         <h3 className="text-lg font-semibold mb-4">Throughput da Rede</h3>
         <div className="h-64 bg-gray-50 rounded-lg flex items-center justify-center">
           <div className="text-center text-gray-500">
@@ -18,7 +18,7 @@ const Monitoring: React.FC = () => (
           </div>
         </div>
       </div>
-      <div className="bg-white rounded-xl shadow-sm border p-6">
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
         <h3 className="text-lg font-semibold mb-4">Latência por Interface</h3>
         <div className="h-64 bg-gray-50 rounded-lg flex items-center justify-center">
           <div className="text-center text-gray-500">
@@ -28,13 +28,13 @@ const Monitoring: React.FC = () => (
         </div>
       </div>
     </div>
-    <div className="bg-white rounded-xl shadow-sm border">
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200">
       <div className="p-6 border-b">
         <h2 className="text-xl font-semibold">Status das Interfaces</h2>
       </div>
       <div className="p-6">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="border rounded-lg p-4">
+          <div className="border border-slate-200 rounded-lg p-4">
             <div className="flex items-center justify-between mb-3">
               <span className="font-medium">bridge1 (LAN)</span>
               <div className="w-3 h-3 bg-green-500 rounded-full"></div>

--- a/src/pages/testing.tsx
+++ b/src/pages/testing.tsx
@@ -40,7 +40,7 @@ const Testing: React.FC = () => {
   };
 
   return (
-    <div className="p-6">
+    <div className="max-w-7xl mx-auto p-6 space-y-8">
       <div className="mb-6">
         <h1 className="text-3xl font-bold mb-2">Teste de Velocidade</h1>
         <p className="text-gray-600">Teste a velocidade da sua conexão em tempo real</p>
@@ -70,7 +70,7 @@ const Testing: React.FC = () => {
         </div>
 
         {results && (
-          <div className="bg-white rounded-xl shadow-sm border p-6">
+          <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
             <h3 className="text-xl font-semibold mb-6 text-center">Resultados</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
               <div className="text-center p-4 bg-green-50 rounded-lg">

--- a/src/pages/users.tsx
+++ b/src/pages/users.tsx
@@ -40,21 +40,21 @@ const UsersPage: React.FC = () => {
   }, []);
 
   return (
-    <div className="p-6">
+    <div className="max-w-7xl mx-auto p-6 space-y-8">
       <div className="mb-6">
         <h1 className="text-3xl font-bold mb-2">Usuários Conectados</h1>
         <p className="text-gray-600">Monitoramento em tempo real de dispositivos na rede</p>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Total Conectados</h3>
             <Users className="w-6 h-6 text-blue-500" />
           </div>
           <div className="text-3xl font-bold text-blue-500">{users.length}</div>
         </div>
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Autorizados</h3>
             <CheckCircle className="w-6 h-6 text-green-500" />
@@ -63,7 +63,7 @@ const UsersPage: React.FC = () => {
             {users.filter(u => u.authorized).length}
           </div>
         </div>
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Intrusos</h3>
             <Shield className="w-6 h-6 text-red-500" />
@@ -72,7 +72,7 @@ const UsersPage: React.FC = () => {
             {users.filter(u => !u.authorized).length}
           </div>
         </div>
-        <div className="bg-white rounded-xl shadow-sm p-6 border">
+        <div className="bg-white rounded-xl shadow-sm p-6 border border-slate-200">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold">Tráfego Total</h3>
             <Activity className="w-6 h-6 text-purple-500" />
@@ -83,7 +83,7 @@ const UsersPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm border">
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200">
         <div className="p-6 border-b flex items-center justify-between">
           <h2 className="text-xl font-semibold">Dispositivos Ativos</h2>
           <div className="flex items-center space-x-2">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [],
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }
-


### PR DESCRIPTION
## Summary
- apply Tailwind base styles and Inter font
- extend Tailwind config and use a neutral gradient theme
- restyle sidebar and header
- tweak layout across all pages
- update failing test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68857a63d050832d991c2e3888092e1f